### PR TITLE
Increase compatibility with `gulp-pug` package.

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,7 +46,8 @@ const gulpPug3 = function (opts) {
             
             opts.filename = opts.filename || path;
             
-            const locals   = opts.locals || {};
+            const fileLocals = (file.data == null || typeof file.data !== 'object') ? {} : file.data;
+            const locals   = Object.assign({}, (opts.locals || {}), fileLocals);
             const contents = file.contents.toString();
             const compiled = opts.client
                     ? pug.compileClient(contents, opts)


### PR DESCRIPTION
I would like to use this as a drop-in replacement for `gulp-pug`, but it's missing one extremely useful features from the official plugin: if the `data` property on a VinylFS file exists, it will be used as a source of local variables within the pug template.

https://github.com/gulp-community/gulp-pug/blob/0dee7f7dd98e7671b44bd6b1576058e5d2a5cde8/index.js#L16

This small pull request adds that feature back.
