### PR TITLE
Don't reuse polluted opts object across multiple input files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ const pugOptKeys = [
 	'name'                    // compileClient
 ];
 
-module.exports = (opts) => {
+module.exports = (optsBase) => {
 
-    opts = opts || {};
-    const keys = Object.keys(opts);
+    optsBase = optsBase || {};
+    const keys = Object.keys(optsBase);
 
     keys.forEach((key) => {
         if (pugOptKeys.indexOf(key) < 0) {
@@ -33,6 +33,9 @@ module.exports = (opts) => {
     });
 
     return through.obj((file, encoding, callback) => {
+        // don't re-use opts as we may be called by gulp multiple times
+        // for different files
+        const opts = Object.assign({}, optsBase);
 
         if (!file.isBuffer()) {
             throw new Error(`${PLUGIN_NAME}: Buffer Only!`);


### PR DESCRIPTION
Fix for: https://github.com/orcunsaltik/gulp-pug-3/issues/2

The bug is [here](https://github.com/orcunsaltik/gulp-pug-3/blob/master/index.js#L48)... the opts object is changed for each file...but then reused for subsequent files.

You want the user to be able to hard-specify an output filename in opts.
However when a user doesn't specify, in the multi-input-file gulp case...the first filename gets used for the subsequent files instead of using the path.

This also results in error messages pointing at the wrong file...so lots of mess.

Simplest thing is to not re-use the given config for each file.